### PR TITLE
fix(PostController): handle null pointer exception on eventId

### DIFF
--- a/src/main/java/com/gorillaz/app/controller/PostController.java
+++ b/src/main/java/com/gorillaz/app/controller/PostController.java
@@ -81,7 +81,9 @@ public class PostController {
             return ResponseEntity.notFound().build();
         }
 
-        GetPostDTO postDto = new GetPostDTO(post.getTitle(), post.getSubtitle(), post.getText(), post.getPostDate(), post.getAdmId().getName(), post.getEventId().getId());
+        var eventId = post.getEventId() != null ? post.getEventId().getId() : null;
+
+        GetPostDTO postDto = new GetPostDTO(post.getTitle(), post.getSubtitle(), post.getText(), post.getPostDate(), post.getAdmId().getName(), eventId);
 
         return ResponseEntity.ok(postDto);
     }


### PR DESCRIPTION
## O que foi feito ?

handling para evitar null pointer exception ao fazer o `GET` de um post específico, no qual não tem um `eventId` atribuído